### PR TITLE
feat: add pagination buttons component

### DIFF
--- a/src/components/PaginationButtons.js
+++ b/src/components/PaginationButtons.js
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+import arrowLeftIcon from '../assets/icon-arrow-left.svg';
+import arrowRightIcon from '../assets/icon-arrow-right.svg';
+
+const PAGES = [1, 2, 3, 4, 5];
+const getAltMessage = (direction) => `${direction}으로 페이지 이동`;
+
+export default function PaginationButtons() {
+  return (
+    <S.ButtonList>
+      <S.PageButton>
+        <img src={arrowLeftIcon} alt={getAltMessage('왼쪽')} />
+      </S.PageButton>
+      {PAGES.map((page) => {
+        return (
+          <S.PageButton key={page} value={page}>
+            {page}
+          </S.PageButton>
+        );
+      })}
+      <S.PageButton>
+        <img src={arrowRightIcon} alt={getAltMessage('오른쪽')} />
+      </S.PageButton>
+    </S.ButtonList>
+  );
+}
+
+const S = {};
+
+S.ButtonList = styled.ul``;
+S.PageButton = styled.li``;

--- a/src/components/PaginationButtons.js
+++ b/src/components/PaginationButtons.js
@@ -27,5 +27,17 @@ export default function PaginationButtons() {
 
 const S = {};
 
-S.ButtonList = styled.ul``;
-S.PageButton = styled.li``;
+S.ButtonList = styled.ul`
+  display: flex;
+`;
+
+S.PageButton = styled.li`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 40px;
+  height: 40px;
+  font-size: ${({ theme }) => theme.font.size.lg};
+  line-height: ${({ theme }) => theme.font.lineHeight.lg};
+  color: ${({ theme }) => theme.grayScale.gray40};
+`;

--- a/src/components/PaginationButtons.js
+++ b/src/components/PaginationButtons.js
@@ -1,29 +1,34 @@
-import styled from 'styled-components';
-import arrowLeftIcon from '../assets/icon-arrow-left.svg';
-import arrowRightIcon from '../assets/icon-arrow-right.svg';
+import styled, { css } from 'styled-components';
+import { ReactComponent as ArrowLeftIcon } from '../assets/icon-arrow-left.svg';
+import { ReactComponent as ArrowRightIcon } from '../assets/icon-arrow-right.svg';
 
 const PAGES = [1, 2, 3, 4, 5];
-const getAltMessage = (direction) => `${direction}으로 페이지 이동`;
 
-export default function PaginationButtons() {
+export default function PaginationButtons({ onClick }) {
   return (
     <S.ButtonList>
       <S.PageButton>
-        <img src={arrowLeftIcon} alt={getAltMessage('왼쪽')} />
+        <S.ArrowLeftIcon />
       </S.PageButton>
-      {PAGES.map((page) => {
+      {PAGES.map((page, index) => {
         return (
-          <S.PageButton key={page} value={page}>
+          <S.PageButton onClick={onClick} key={index} value={page}>
             {page}
           </S.PageButton>
         );
       })}
       <S.PageButton>
-        <img src={arrowRightIcon} alt={getAltMessage('오른쪽')} />
+        <S.ArrowRighttIcon />
       </S.PageButton>
     </S.ButtonList>
   );
 }
+
+const fontStyle = css`
+  font-size: ${({ theme }) => theme.font.size.lg};
+  line-height: ${({ theme }) => theme.font.lineHeight.lg};
+  color: ${({ theme }) => theme.grayScale.gray40};
+`;
 
 const S = {};
 
@@ -37,7 +42,13 @@ S.PageButton = styled.li`
   align-items: center;
   width: 40px;
   height: 40px;
-  font-size: ${({ theme }) => theme.font.size.lg};
-  line-height: ${({ theme }) => theme.font.lineHeight.lg};
-  color: ${({ theme }) => theme.grayScale.gray40};
+  ${fontStyle}
+`;
+
+S.ArrowLeftIcon = styled(ArrowLeftIcon)`
+  ${fontStyle}
+`;
+
+S.ArrowRightIcon = styled(ArrowRightIcon)`
+  ${fontStyle}
 `;


### PR DESCRIPTION
## 개요
페이지 네이션 버튼을 구현했습니다. 이후에 hooks 를 추가해서 기능도 더해야 합니다.
배열 렌더링에 좌우 화살표 svg 컴포넌트도 포함시키려는 시도를 했으나,
배열 안에는 동일한 타입의 데이타를 두는 것을 권장하고, 
숫자 페이지 버튼과는 받아와야 하는 onClick 함수가 달라서 결국 원래 하던대로 돌렸습니다.

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 팀원에게 전하고 싶은 말
-
-
-

## 스크린샷

```js
export default function PaginationButtons({ onClick }) {
  return (
    <S.ButtonList>
      <S.PageButton>
        <S.ArrowLeftIcon />
      </S.PageButton>
      {PAGES.map((page, index) => {
        return (
          <S.PageButton onClick={onClick} key={index} value={page}>
            {page}
          </S.PageButton>
        );
      })}
      <S.PageButton>
        <S.ArrowRighttIcon />
      </S.PageButton>
    </S.ButtonList>
  );
}
```
