### PR TITLE
feat: add toast component

### DIFF
--- a/src/components/Toast.js
+++ b/src/components/Toast.js
@@ -1,0 +1,30 @@
+import styled from 'styled-components';
+import { theme } from '../utils/theme';
+
+export default function Toast({ content = 'URL이 복사되었습니다' }) {
+  return (
+    <S.ToastContainer>
+      <S.ToastContent>{content}</S.ToastContent>
+    </S.ToastContainer>
+  );
+}
+
+const S = {};
+
+S.ToastContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 12px 20px;
+  border-radius: 8px;
+  background-color: ${theme.grayScale.gray60};
+  box-shadow: ${theme.boxShadow.medium};
+`;
+
+S.ToastContent = styled.span`
+  font-family: ${theme.font.family};
+  font-size: ${theme.font.size.xs};
+  font-weight: ${theme.font.weight.medium};
+  line-height: ${theme.font.lineHeight.xs};
+  color: ${theme.grayScale.gray10};
+`;

--- a/src/components/Toast.js
+++ b/src/components/Toast.js
@@ -1,7 +1,9 @@
 import styled from 'styled-components';
 import { theme } from '../utils/theme';
 
-export default function Toast({ content = 'URL이 복사되었습니다' }) {
+const DEFAULT_CONTENT_MESSAGE = 'URL이 복사되었습니다';
+
+export default function Toast({ content = DEFAULT_CONTENT_MESSAGE }) {
   return (
     <S.ToastContainer>
       <S.ToastContent>{content}</S.ToastContent>
@@ -15,6 +17,7 @@ S.ToastContainer = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+  width: fit-content;
   padding: 12px 20px;
   border-radius: 8px;
   background-color: ${theme.grayScale.gray60};


### PR DESCRIPTION
## 개요
toast 컴포넌트를 작업했습니다. 간단한 레이아웃과, props 를 사용해 내용을 변경할 수 있게끔 작업했습니다. 
## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 팀원에게 전하고 싶은 말
- 이 Toast 부분은 모바일, 태블릿, 모니터 모든 경우에서 167px x 42px 이 적용되고 있습니다. 따라서 그냥 고정값으로 넣을까 했지만 아직 글로벌 스타일 적용 전이라 그런지 border 값이 추가로 더 들어가있는 것 같아서 우선 뺐습니다. (수정사항: width: fit content를 주면서 수정을 했습니다.) 
- (수정사항) 회의 때 내용을 참고해 내용 변수를 추가했고, 그 변수를 content 기본값으로 주었습니다. 
- 

## 스크린샷
![image](https://github.com/KingNono1030/sprint7_team8_open-mind/assets/166420311/971684e0-c291-42a2-8c47-d81026665915)
![image](https://github.com/KingNono1030/sprint7_team8_open-mind/assets/166420311/40d1fb3b-2b4e-4fd3-b349-b1dde4d64ba9)
