### PR TITLE
feat: adjust layout for questionFeed page

### DIFF
--- a/src/components/AnswerStateBadge.js
+++ b/src/components/AnswerStateBadge.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
 
-export default function AnswerStateBadge({ isAnswered }) {
-    return (
-      <S.AnswerStateBadge answered={isAnswered}>
-        {isAnswered ? '답변 완료' : '미답변'}
-      </S.AnswerStateBadge>
-    );
+export default function AnswerStateBadge({ isAnswered, className }) {
+  return (
+    <S.AnswerStateBadge answered={isAnswered} className={className}>
+      {isAnswered ? '답변 완료' : '미답변'}
+    </S.AnswerStateBadge>
+  );
 }
 
 const S = {
@@ -21,13 +21,13 @@ const S = {
 };
 
 const answeredStyles = css`
-  color: #542F1A;
-  background-color: #FFFFFF;
-  border: 1px solid #542F1A;
+  color: #542f1a;
+  background-color: #ffffff;
+  border: 1px solid #542f1a;
 `;
 
 const notAnsweredStyles = css`
   color: #818181;
-  background-color: #FFFFFF;
+  background-color: #ffffff;
   border: 1px solid #818181;
 `;

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -2,6 +2,7 @@ import styled, { css } from 'styled-components';
 import { ReactComponent as ArrowRightIcon } from '../assets/icon-arrow-right.svg';
 
 export default function Button({
+  className,
   variant = '',
   onClick = null,
   type = 'button',
@@ -14,6 +15,7 @@ export default function Button({
 }) {
   return (
     <S.Button
+      className={className}
       variant={variant}
       onClick={onClick}
       type={type}

--- a/src/components/Inquiry.js
+++ b/src/components/Inquiry.js
@@ -36,12 +36,12 @@ export default function Inquiry({}) {
 
   return (
     <S.InquiryContainer>
-      <AnswerStateBadge isAnswerEmpty={isAnswerEmpty} />
+      <S.AnswerStateBadge isAnswerEmpty={isAnswerEmpty} />
       <Question content={questionContent} timeAgp={getTimeAgo(questionDate)} />
       <Answer
         content={answerContent}
-        timeAgp={getTimeAgo(answerDate)}
-        subject={subjectId}
+        answerTime={getTimeAgo(answerDate)}
+        profileId='아초는고양이'
       />
       <S.ReactionWrapper>
         <Reaction like={like} dislike={dislike} />
@@ -52,6 +52,10 @@ export default function Inquiry({}) {
 
 const S = {};
 
+S.AnswerStateBadge = styled(AnswerStateBadge)`
+  width: fit-content;
+`;
+
 S.InquiryContainer = styled.div`
   display: flex;
   flex-direction: column;
@@ -59,8 +63,9 @@ S.InquiryContainer = styled.div`
   width: 100%;
   padding: ${({ theme }) => theme.spacing.xl};
   border: ${({ theme }) =>
-    `${theme.borderWidth.thin} solid ${theme.brownScale.brown20}`};
-  background-color: ${({ theme }) => theme.brownScale.brown10};
+    `${theme.borderWidth.thin} solid ${theme.grayScale.gray10}`};
+  border-radius: ${({ theme }) => theme.rounded.md};
+  background-color: ${({ theme }) => theme.grayScale.gray10};
   box-shadow: ${({ theme }) => theme.boxShadow.light};
 `;
 

--- a/src/components/Inquiry.js
+++ b/src/components/Inquiry.js
@@ -37,13 +37,10 @@ export default function Inquiry({}) {
   return (
     <S.InquiryContainer>
       <AnswerStateBadge isAnswerEmpty={isAnswerEmpty} />
-      <Question
-        content={questionContent}
-        timeAgp={getTimeAgo(questionTimeAgo)}
-      />
+      <Question content={questionContent} timeAgp={getTimeAgo(questionDate)} />
       <Answer
         content={answerContent}
-        timeAgp={getTimeAgo(answerTimeAgo)}
+        timeAgp={getTimeAgo(answerDate)}
         subject={subjectId}
       />
       <S.ReactionWrapper>

--- a/src/components/Inquiry.js
+++ b/src/components/Inquiry.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import Badge from './Badge';
+import AnswerStateBadge from './AnswerStateBadge';
 import Question from './Question';
 import Answer from './Answer';
 import Reaction from './Reaction';
@@ -36,7 +36,7 @@ export default function Inquiry({}) {
 
   return (
     <S.InquiryContainer>
-      <Badge isAnswerEmpty={isAnswerEmpty} />
+      <AnswerStateBadge isAnswerEmpty={isAnswerEmpty} />
       <Question
         content={questionContent}
         timeAgp={getTimeAgo(questionTimeAgo)}

--- a/src/components/Inquiry.js
+++ b/src/components/Inquiry.js
@@ -39,7 +39,7 @@ export default function Inquiry({}) {
       <S.AnswerStateBadge isAnswerEmpty={isAnswerEmpty} />
       <Question content={questionContent} timeAgp={getTimeAgo(questionDate)} />
       <Answer
-        content={answerContent}
+        answerContent={answerContent}
         answerTime={getTimeAgo(answerDate)}
         profileId='아초는고양이'
       />

--- a/src/components/InquirySection.js
+++ b/src/components/InquirySection.js
@@ -23,6 +23,8 @@ export default function InquirySection({ className }) {
       )}
       <S.InqiryWrapper>
         <Inquiry />
+        <Inquiry />
+        <Inquiry />
       </S.InqiryWrapper>
     </S.InquiryContainer>
   );
@@ -67,6 +69,9 @@ S.EmptyImage = styled.img`
 `;
 
 S.InqiryWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
   width: 100%;
   padding: 0 16px 16px 16px;
+  gap: 16px;
 `;

--- a/src/components/InquirySection.js
+++ b/src/components/InquirySection.js
@@ -3,12 +3,13 @@ import { theme } from '../utils/theme';
 import styled from 'styled-components';
 import emptyImage from '../assets/Image-empty-inquiry.svg';
 import messageIcon from '../assets/icon-message-brown.svg';
+import Inquiry from './Inquiry';
 
 export default function InquirySection({ className }) {
   const [questionCount, setQuestionCount] = useState(3);
 
   return (
-    <S.InquiryWrapper className={className}>
+    <S.InquiryContainer className={className}>
       <S.SectionHeader>
         <S.MessageIcon src={messageIcon} alt='질문창 메시지 아이콘' />
         <S.QuestionNumber>
@@ -20,15 +21,20 @@ export default function InquirySection({ className }) {
       {questionCount === 0 && (
         <S.EmptyImage src={emptyImage} alt='질문 없을때 빈 상자 아이콘' />
       )}
-    </S.InquiryWrapper>
+      <S.InqiryWrapper>
+        <Inquiry />
+      </S.InqiryWrapper>
+    </S.InquiryContainer>
   );
 }
 
 const S = {};
 
-S.InquiryWrapper = styled.div`
+S.InquiryContainer = styled.div`
   display: flex;
+  flex-direction: column;
   justify-content: center;
+  align-items: center;
   position: relative;
   border: 1px solid ${theme.brownScale.brown20};
   border-radius: ${theme.rounded.md};
@@ -58,4 +64,9 @@ S.EmptyImage = styled.img`
   top: 106px;
   width: 114px;
   height: 118px;
+`;
+
+S.InqiryWrapper = styled.div`
+  width: 100%;
+  padding: 0 16px 16px 16px;
 `;

--- a/src/components/InquirySection.js
+++ b/src/components/InquirySection.js
@@ -4,11 +4,11 @@ import styled from 'styled-components';
 import emptyImage from '../assets/Image-empty-inquiry.svg';
 import messageIcon from '../assets/icon-message-brown.svg';
 
-export default function InquirySection() {
+export default function InquirySection({ className }) {
   const [questionCount, setQuestionCount] = useState(3);
 
   return (
-    <S.InquiryWrapper>
+    <S.InquiryWrapper className={className}>
       <S.SectionHeader>
         <S.MessageIcon src={messageIcon} alt='질문창 메시지 아이콘' />
         <S.QuestionNumber>

--- a/src/components/InquirySection.js
+++ b/src/components/InquirySection.js
@@ -51,11 +51,11 @@ S.SectionHeader = styled.div`
 S.MessageIcon = styled.img`
   width: 22px;
   height: 22px;
-  padding: 1px 8px 1px 0;
+  margin-right: 8px;
 `;
 
 S.QuestionNumber = styled.span`
-  font-family: ${theme.font.family};
+  font-family: ${theme.font.family.second};
   font-size: ${theme.font.size.md};
   line-height: ${theme.font.lineHeight.md};
   color: ${theme.brownScale.brown40};

--- a/src/components/Logo.js
+++ b/src/components/Logo.js
@@ -2,10 +2,15 @@ import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import logoImg from '../assets/image-logo.svg';
 
-export default function Logo({ size = 'md' }) {
+export default function Logo({ className, size = 'md' }) {
   return (
     <Link to='/'>
-      <S.LogoImg size={size} src={logoImg} alt='오픈마인드 로고' />
+      <S.LogoImg
+        className={className}
+        size={size}
+        src={logoImg}
+        alt='오픈마인드 로고'
+      />
     </Link>
   );
 }

--- a/src/components/Question.js
+++ b/src/components/Question.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 export default function Question({ content, timeAgp }) {
   return (
     <S.QuestionContainer>
-      <span>질문 · ${timeAgp}</span>
+      <span>질문 · {timeAgp}</span>
       <h2>{content}</h2>
     </S.QuestionContainer>
   );

--- a/src/components/Question.js
+++ b/src/components/Question.js
@@ -3,8 +3,8 @@ import styled from 'styled-components';
 export default function Question({ content, timeAgp }) {
   return (
     <S.QuestionContainer>
-      <span>질문 · {timeAgp}</span>
-      <h2>{content}</h2>
+      <S.QuestionHeader>질문 · {timeAgp}</S.QuestionHeader>
+      <S.QuestionContent>{content}</S.QuestionContent>
     </S.QuestionContainer>
   );
 }

--- a/src/pages/QuestionFeedPage.js
+++ b/src/pages/QuestionFeedPage.js
@@ -1,3 +1,61 @@
+import Logo from '../components/Logo';
+import Banner from '../components/Banner';
+import Profile from '../components/Profile';
+import ShareList from '../components/ShareList';
+import InquirySection from '../components/InquirySection';
+import Button from '../components/Button';
+import styled from 'styled-components';
+
 export default function QuestionFeedPage() {
-  return <div>질문 페이지</div>;
+  return (
+    <>
+      <S.pagecontainer>
+        <S.Logo size='sm' />
+        <Banner page='other' />
+        <S.profileshare>
+          <Profile page='xl' />
+          <ShareList />
+        </S.profileshare>
+        <S.InquirySection />
+      </S.pagecontainer>
+      <S.ButtonContainer>
+        <S.Button variant='floating'>질문 작성</S.Button>
+      </S.ButtonContainer>
+    </>
+  );
 }
+
+const S = {};
+
+S.pagecontainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 40px 24px 48px 24px;
+`;
+
+S.Logo = styled(Logo)`
+  margin-bottom: 12px;
+`;
+
+S.profileshare = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 54px;
+  gap: 12px;
+`;
+
+S.InquirySection = styled(InquirySection)`
+  width: 327px;
+`;
+
+S.Button = styled(Button)`
+  padding: 14.5px 24px;
+`;
+
+S.ButtonContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  padding: 0 24px 24px 0;
+`;

--- a/src/pages/QuestionFeedPage.js
+++ b/src/pages/QuestionFeedPage.js
@@ -5,7 +5,6 @@ import ShareList from '../components/ShareList';
 import InquirySection from '../components/InquirySection';
 import Button from '../components/Button';
 import styled from 'styled-components';
-import Inquiry from '../components/Inquiry';
 
 export default function QuestionFeedPage() {
   return (
@@ -17,9 +16,7 @@ export default function QuestionFeedPage() {
           <Profile page='xl' />
           <ShareList />
         </S.profileshare>
-        <S.InquirySection>
-          <Inquiry />
-        </S.InquirySection>
+        <S.InquirySection />
       </S.PageContainer>
       <S.ButtonContainer>
         <S.Button variant='floating'>질문 작성</S.Button>

--- a/src/pages/QuestionFeedPage.js
+++ b/src/pages/QuestionFeedPage.js
@@ -5,6 +5,7 @@ import ShareList from '../components/ShareList';
 import InquirySection from '../components/InquirySection';
 import Button from '../components/Button';
 import styled from 'styled-components';
+import Inquiry from '../components/Inquiry';
 
 export default function QuestionFeedPage() {
   return (
@@ -16,7 +17,9 @@ export default function QuestionFeedPage() {
           <Profile page='xl' />
           <ShareList />
         </S.profileshare>
-        <S.InquirySection />
+        <S.InquirySection>
+          <Inquiry />
+        </S.InquirySection>
       </S.PageContainer>
       <S.ButtonContainer>
         <S.Button variant='floating'>질문 작성</S.Button>

--- a/src/pages/QuestionFeedPage.js
+++ b/src/pages/QuestionFeedPage.js
@@ -9,7 +9,7 @@ import styled from 'styled-components';
 export default function QuestionFeedPage() {
   return (
     <>
-      <S.pagecontainer>
+      <S.PageContainer>
         <S.Logo size='sm' />
         <Banner page='other' />
         <S.profileshare>
@@ -17,7 +17,7 @@ export default function QuestionFeedPage() {
           <ShareList />
         </S.profileshare>
         <S.InquirySection />
-      </S.pagecontainer>
+      </S.PageContainer>
       <S.ButtonContainer>
         <S.Button variant='floating'>질문 작성</S.Button>
       </S.ButtonContainer>
@@ -27,7 +27,7 @@ export default function QuestionFeedPage() {
 
 const S = {};
 
-S.pagecontainer = styled.div`
+S.PageContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -47,7 +47,7 @@ S.profileshare = styled.div`
 `;
 
 S.InquirySection = styled(InquirySection)`
-  width: 327px;
+  width: 100%;
 `;
 
 S.Button = styled(Button)`


### PR DESCRIPTION
## 개요
questionFeed 페이지를 작업했습니다. 모바일버전 전체적인 레이아웃을 작업했고, 작업하며 수정이 필요한 다른 컴포넌트들을 수정했습니다. 
## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 팀원에게 전하고 싶은 말
- n개의 질문이 있습니다 부분 폰트를 Actor 로 바꾸니 메시지아이콘이 작아지는 경우가 발생했습니다. 다시 Pretendard로 바꿨지만, 메시지 아이콘 크기는 돌아오지 않는 오류가 있습니다. (수정완료)
- 프로필 이미지는 아직 불러오지 않아서 비어있습니다. alt 값만 출력이 되고있는 상태입니다. 추후 수정이 필요합니다! 
- 버튼쪽 폰트의 크기인지 굵기 때문인지 묘하게 피그마랑 다른 것 같습니다. 수정이 필요할 것 같습니다. 
- 스타일드 상속을 위해 다른 컴포넌트들의 className 프롭스를 뚫어놓는 등 다른 컴포넌트들도 약간의 수정을 하였습니다. 

## 스크린샷
![image](https://github.com/KingNono1030/sprint7_team8_open-mind/assets/166420311/9c800f28-b99e-41fd-a763-1657004cfabd)
-> 폰트 수정함. 
![image](https://github.com/KingNono1030/sprint7_team8_open-mind/assets/166420311/32dbbaa2-0162-4729-a17d-53012695c16c)

![image](https://github.com/KingNono1030/sprint7_team8_open-mind/assets/166420311/8c8684f0-d0d7-4238-80b9-9654181e0e72)
![image](https://github.com/KingNono1030/sprint7_team8_open-mind/assets/166420311/3d6272f6-1d5c-4816-b3f9-0f1366d6ee94)

