### PR TITLE
feat: add responsiveness to questionFeed page

### DIFF
--- a/src/components/Banner.js
+++ b/src/components/Banner.js
@@ -1,9 +1,9 @@
 import styled, { css } from 'styled-components';
 import banner from '../assets/image-banner.svg';
 
-export default function Banner({ page }) {
+export default function Banner({ className, page }) {
   return (
-    <S.BannerContainer page={page}>
+    <S.BannerContainer className={className} page={page}>
       <S.BannerImg src={banner} page={page} alt='Banner Image' />
     </S.BannerContainer>
   );

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -11,7 +11,6 @@ export default function Button({
   hasArrow = false,
   isArrowRight = true,
   fontSize = 'lg',
-  className = '',
   children = '',
 }) {
   return (
@@ -25,7 +24,6 @@ export default function Button({
       hasArrow={hasArrow}
       fontSize={fontSize}
       isArrowRight={isArrowRight}
-      className={className}
     >
       {children}
       {hasArrow && <S.Arrow isArrowRight={isArrowRight} />}

--- a/src/pages/QuestionFeedPage.js
+++ b/src/pages/QuestionFeedPage.js
@@ -75,6 +75,10 @@ S.InquirySection = styled(InquirySection)`
 S.Button = styled(Button)`
   padding: 14.5px 24px;
   gap: 0;
+
+  @media screen and (min-width: 768px) {
+    padding: 14.5px 49.5px;
+  }
 `;
 
 S.ButtonContainer = styled.div`

--- a/src/pages/QuestionFeedPage.js
+++ b/src/pages/QuestionFeedPage.js
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import Logo from '../components/Logo';
 import Banner from '../components/Banner';
 import Profile from '../components/Profile';
@@ -11,7 +12,9 @@ export default function QuestionFeedPage() {
     <>
       <S.PageContainer>
         <S.Logo size='sm' />
-        <Banner page='other' />
+        <S.BannerContainer>
+          <S.Banner page='other' />
+        </S.BannerContainer>
         <S.profileshare>
           <Profile page='xl' />
           <ShareList />
@@ -19,7 +22,9 @@ export default function QuestionFeedPage() {
         <S.InquirySection />
       </S.PageContainer>
       <S.ButtonContainer>
-        <S.Button variant='floating'>질문 작성</S.Button>
+        <S.Button variant='floating'>
+          질문 작성<S.Do>하기</S.Do>
+        </S.Button>
       </S.ButtonContainer>
     </>
   );
@@ -32,6 +37,19 @@ S.PageContainer = styled.div`
   flex-direction: column;
   align-items: center;
   padding: 40px 24px 48px 24px;
+
+  @media screen and (min-width: 768px) {
+    padding: 50px 32px 58px 32px;
+  }
+`;
+
+S.BannerContainer = styled.div`
+  width: 100%;
+`;
+
+S.Banner = styled(Banner)`
+  width: 100%;
+  object-fit: cover;
 `;
 
 S.Logo = styled(Logo)`
@@ -48,14 +66,26 @@ S.profileshare = styled.div`
 
 S.InquirySection = styled(InquirySection)`
   width: 100%;
+
+  @media screen and (min-width: 1200px) {
+    width: 716px;
+  }
 `;
 
 S.Button = styled(Button)`
   padding: 14.5px 24px;
+  gap: 0;
 `;
 
 S.ButtonContainer = styled.div`
   display: flex;
   justify-content: flex-end;
   padding: 0 24px 24px 0;
+`;
+
+S.Do = styled.span`
+  display: none;
+  @media screen and (min-width: 768px) {
+    display: inline;
+  }
 `;

--- a/src/pages/QuestionFeedPage.js
+++ b/src/pages/QuestionFeedPage.js
@@ -1,4 +1,3 @@
-import { useState, useEffect } from 'react';
 import Logo from '../components/Logo';
 import Banner from '../components/Banner';
 import Profile from '../components/Profile';


### PR DESCRIPTION
## 개요
questionFeed 페이지의 반응형을 구현했습니다. 768px 이상일 때 버튼부분의 내용이 질문 작성하기 로 바뀌는 부분과 padding 값이 조금씩 달라진 걸 작업하였습니다. 

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 팀원에게 전하고 싶은 말
- 배너 부분이 1200px을 넘어가면 잘리는 오류가 발생합니다.
- 
-

## 스크린샷
![image](https://github.com/KingNono1030/sprint7_team8_open-mind/assets/166420311/f5517700-49ce-4058-a630-63885d866bf1)
![image](https://github.com/KingNono1030/sprint7_team8_open-mind/assets/166420311/ce7a2e30-af52-4978-8519-ef7944bd9528)
![image](https://github.com/KingNono1030/sprint7_team8_open-mind/assets/166420311/c281af58-bf5d-45ac-bb46-5acf079bccaa)
![image](https://github.com/KingNono1030/sprint7_team8_open-mind/assets/166420311/6e1f71da-87fc-4181-8489-45f50f7e6d74)
![image](https://github.com/KingNono1030/sprint7_team8_open-mind/assets/166420311/dad41806-e4a9-463f-a6fb-cdeb9876015b)

